### PR TITLE
Structural appearance proposals (SP1–SP5)

### DIFF
--- a/public/style/blog.css
+++ b/public/style/blog.css
@@ -1,3 +1,5 @@
+@import "chips.css";
+
 img {
     max-width: 100%;
     height: auto;
@@ -11,47 +13,9 @@ img {
     padding-right: 2rem;
 }
 
-/* ── Topic chips ─────────────────────────────────────────────────────────── */
-.topic-chip {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-height: 2.75rem;
-    border-radius: 999px;
-    padding: 0.35rem 0.8rem;
-    font-size: 0.9rem;
-    border: 1px solid var(--border);
-    color: var(--accent);
-    background: transparent;
-    text-decoration: none;
-    transition: color 0.15s, border-color 0.15s;
-}
-
-.topic-chip:hover,
-.topic-chip:focus {
-    color: var(--accent);
-    border-color: var(--accent);
-}
-
-/* ── Domain badge ─────────────────────────────────────────────────────────── */
-.domain-badge {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-height: 2.75rem;
-    border-radius: 999px;
-    padding: 0.35rem 0.9rem;
-    font-size: 0.9rem;
-    font-weight: 600;
-    background: color-mix(in srgb, var(--accent) 12%, transparent);
-    color: var(--accent);
-    border: 1px solid color-mix(in srgb, var(--accent) 45%, transparent);
-    text-decoration: none;
-    transition: background 0.15s, border-color 0.15s;
-}
-
-.domain-badge:hover,
-.domain-badge:focus {
-    background: color-mix(in srgb, var(--accent) 20%, transparent);
-    border-color: var(--accent);
+@media (max-width: 600px) {
+    .wrapper {
+        padding-left: 1rem;
+        padding-right: 1rem;
+    }
 }

--- a/public/style/chips.css
+++ b/public/style/chips.css
@@ -1,0 +1,44 @@
+/* ── Topic chips ─────────────────────────────────────────────────────────── */
+.topic-chip {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 2.75rem;
+    border-radius: 999px;
+    padding: 0.35rem 0.8rem;
+    font-size: 0.9rem;
+    border: 1px solid var(--border);
+    color: var(--accent);
+    background: transparent;
+    text-decoration: none;
+    transition: color 0.15s, border-color 0.15s;
+}
+
+.topic-chip:hover,
+.topic-chip:focus {
+    color: var(--accent);
+    border-color: var(--accent);
+}
+
+/* ── Domain badge ─────────────────────────────────────────────────────────── */
+.domain-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 2.75rem;
+    border-radius: 999px;
+    padding: 0.35rem 0.9rem;
+    font-size: 0.9rem;
+    font-weight: 600;
+    background: color-mix(in srgb, var(--accent) 12%, transparent);
+    color: var(--accent);
+    border: 1px solid color-mix(in srgb, var(--accent) 45%, transparent);
+    text-decoration: none;
+    transition: background 0.15s, border-color 0.15s;
+}
+
+.domain-badge:hover,
+.domain-badge:focus {
+    background: color-mix(in srgb, var(--accent) 20%, transparent);
+    border-color: var(--accent);
+}

--- a/public/style/global.css
+++ b/public/style/global.css
@@ -18,6 +18,8 @@
   --accent: #9d2235;
   --accent-strong: #7a1626;
   --border: #c0ae94;
+  --shadow-1: 0 6px 24px -12px rgba(40, 20, 10, 0.18);
+  --shadow-2: 0 10px 40px -16px rgba(40, 20, 10, 0.25);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -25,12 +27,14 @@
     --color-light: #1F2937;
 
     --bg: #14171d;
-    --bg-panel: #1b1f27;
+    --bg-panel: #252a35;
     --fg: #e9e6e1;
     --muted: #b5bcc7;
     --accent: #eea0ae;
     --accent-strong: #ffa3b3;
     --border: #404857;
+    --shadow-1: 0 6px 24px -12px rgba(0, 0, 0, 0.5), inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+    --shadow-2: 0 12px 40px -16px rgba(0, 0, 0, 0.6), inset 0 0 0 1px rgba(255, 255, 255, 0.07);
   }
 }
 

--- a/public/style/home.css
+++ b/public/style/home.css
@@ -14,3 +14,9 @@ h2 {
     font-weight: 700;
     font-size: clamp(1.5rem, 1rem + 1.25vw, 2rem);
 }
+
+@media (max-width: 600px) {
+    body {
+        padding: 2rem 1.25rem;
+    }
+}

--- a/public/style/summaries.css
+++ b/public/style/summaries.css
@@ -1,3 +1,5 @@
+@import "chips.css";
+
 img {
     max-width: 100%;
     height: auto;
@@ -9,4 +11,11 @@ img {
     margin-right: auto;
     padding-left: 2rem;
     padding-right: 2rem;
+}
+
+@media (max-width: 600px) {
+    .wrapper {
+        padding-left: 1rem;
+        padding-right: 1rem;
+    }
 }

--- a/src/components/PostLink.astro
+++ b/src/components/PostLink.astro
@@ -16,7 +16,7 @@ return new Date(date).toUTCString().replace(/(\d\d\d\d) .*/, '$1'); // remove ev
     background: var(--bg-panel);
     border: 1px solid var(--border);
     border-radius: 16px;
-    box-shadow: 0 6px 24px -12px rgba(40, 20, 10, 0.18);
+    box-shadow: var(--shadow-1);
     padding: 1.75rem 2rem;
     margin: 1.5rem 0;
     transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
@@ -24,7 +24,7 @@ return new Date(date).toUTCString().replace(/(\d\d\d\d) .*/, '$1'); // remove ev
 
   .post-entry:hover {
     transform: translateY(-3px);
-    box-shadow: 0 10px 40px -16px rgba(40, 20, 10, 0.25);
+    box-shadow: var(--shadow-2);
     border-color: var(--accent);
   }
 

--- a/src/components/TopicTags.astro
+++ b/src/components/TopicTags.astro
@@ -7,7 +7,7 @@ const chips = cats.map((c) => ({
 }));
 const domainSlug = domain ? String(domain).toLowerCase() : '';
 const domainLabel = domain ? String(domain).charAt(0).toUpperCase() + String(domain).slice(1) : '';
-// .domain-badge visual theming is in public/style/blog.css
+// .domain-badge visual theming is in public/style/chips.css
 ---
 {(domain || chips.length > 0) && (
   <ul class="topics">

--- a/src/components/WidgetEmbed.astro
+++ b/src/components/WidgetEmbed.astro
@@ -1,21 +1,75 @@
 ---
 const { slug, height = 600, title, src } = Astro.props;
+const url = src ?? `https://${slug}.widgets.beshir.org`;
+const name = title ?? slug;
 ---
-<iframe
-  src={src ?? `https://${slug}.widgets.beshir.org`}
-  width="100%"
-  height={height}
-  loading="lazy"
-  title={title ?? slug}
-  class="widget-embed"
-></iframe>
-
+<div class="widget-frame" style={`min-height:${height}px`}>
+  <div class="widget-placeholder">
+    <span class="widget-icon">
+      <svg width="40" height="40" viewBox="0 0 40 40" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <rect x="3" y="3" width="34" height="34" rx="6"/>
+        <line x1="3" y1="12" x2="37" y2="12"/>
+        <line x1="10" y1="20" x2="30" y2="20"/>
+        <line x1="10" y1="27" x2="24" y2="27"/>
+      </svg>
+    </span>
+    <div class="widget-name">{name}</div>
+    <a href={url} class="widget-cta">View full page →</a>
+  </div>
+  <iframe
+    src={url}
+    width="100%"
+    height={height}
+    loading="lazy"
+    title={name}
+    class="widget-embed"
+  ></iframe>
+</div>
 <style>
-  .widget-embed {
-    display: block;
-    width: 100%;
+  .widget-frame {
+    position: relative;
     border: 1px solid var(--border);
     border-radius: 10px;
+    overflow: hidden;
     background: var(--bg-panel);
+  }
+  .widget-placeholder {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.6rem;
+    text-align: center;
+    padding: 1.5rem;
+  }
+  .widget-icon {
+    color: var(--accent);
+    line-height: 0;
+  }
+  .widget-name {
+    font-family: 'Spectral', serif;
+    font-weight: 700;
+    color: var(--accent);
+    font-size: 1.1rem;
+  }
+  .widget-cta {
+    font-size: 0.85rem;
+    color: var(--accent);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+  .widget-cta:hover {
+    opacity: 0.8;
+  }
+  .widget-embed {
+    position: relative;
+    z-index: 1;
+    display: block;
+    width: 100%;
+    border: 0;
+    background: transparent;
   }
 </style>

--- a/src/layouts/blog.astro
+++ b/src/layouts/blog.astro
@@ -20,10 +20,6 @@ const { content } = Astro.props;
         font-family: 'Spectral', serif;
       }
 
-      .wrapper {
-        max-width: 56rem;
-      }
-
       .title {
         margin-top: 3rem;
         margin-bottom: 1rem;
@@ -49,10 +45,12 @@ const { content } = Astro.props;
       .article {
         margin-top: 2rem;
         margin-bottom: 6rem;
+        max-width: 46rem;
+        margin-inline: auto;
         background: var(--bg-panel);
         border: 1px solid var(--border);
         border-radius: 16px;
-        box-shadow: 0 10px 40px -16px rgba(40, 20, 10, 0.25);
+        box-shadow: var(--shadow-2);
         padding: 2rem 2.5rem;
 
         :global(p), :global(> ul) {

--- a/src/layouts/summary.astro
+++ b/src/layouts/summary.astro
@@ -29,12 +29,12 @@ const { content } = Astro.props;
       }
 
       .description {
-        margin-bottom: 4rem;
-        font-size: 1.4em;
+        margin-bottom: 3rem;
+        font-size: 1.25em;
         font-weight: 400;
-        text-align: left;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
+        font-style: italic;
+        color: var(--muted);
+        line-height: 1.5;
       }
 
       .img {
@@ -46,6 +46,8 @@ const { content } = Astro.props;
       .article {
         margin-top: 4rem;
         margin-bottom: 6rem;
+        max-width: 42rem;
+        margin-inline: auto;
 
         :global(p), :global(> ul) {
           line-height: 1.6;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -25,13 +25,13 @@ import '@fontsource/spectral/700.css';
         }
 
         main {
-            max-width: 34rem;
+            max-width: 40rem;
             width: 100%;
             background: var(--bg-panel);
             border: 1px solid var(--border);
             border-radius: 16px;
             padding: 2rem 2.5rem 2.5rem;
-            box-shadow: 0 10px 40px -16px rgba(40, 20, 10, 0.25);
+            box-shadow: var(--shadow-2);
         }
 
         .bio {

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -79,7 +79,7 @@ for (const [slug, pair] of Object.entries(sources)) {
             background: var(--bg-panel);
             border: 1px solid var(--border);
             border-radius: 16px;
-            box-shadow: 0 6px 24px -12px rgba(40, 20, 10, 0.18);
+            box-shadow: var(--shadow-1);
             padding: 2rem 2.5rem;
             margin-bottom: 2rem;
             color: var(--fg);
@@ -89,7 +89,7 @@ for (const [slug, pair] of Object.entries(sources)) {
 
         .featured-card:hover {
             transform: translateY(-3px);
-            box-shadow: 0 10px 40px -16px rgba(40, 20, 10, 0.25);
+            box-shadow: var(--shadow-2);
             border-color: var(--accent);
             text-decoration: none;
         }
@@ -122,7 +122,7 @@ for (const [slug, pair] of Object.entries(sources)) {
             background: var(--bg-panel);
             border: 1px solid var(--border);
             border-radius: 16px;
-            box-shadow: 0 6px 24px -12px rgba(40, 20, 10, 0.18);
+            box-shadow: var(--shadow-1);
             overflow: hidden;
             display: flex;
             flex-direction: row;
@@ -134,7 +134,7 @@ for (const [slug, pair] of Object.entries(sources)) {
 
         .widget-card:hover {
             transform: translateY(-3px);
-            box-shadow: 0 10px 40px -16px rgba(40, 20, 10, 0.25);
+            box-shadow: var(--shadow-2);
             border-color: var(--accent);
             text-decoration: none;
         }
@@ -197,13 +197,22 @@ for (const [slug, pair] of Object.entries(sources)) {
         /* MCP list */
         .mcp-list {
             list-style: none;
-            padding: 0;
             margin: 0;
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 16px;
+            box-shadow: var(--shadow-1);
+            padding: 0.5rem 1.5rem;
         }
 
         .mcp-list li {
-            padding: 0.3rem 0;
+            padding: 0.75rem 0;
             line-height: 1.5;
+            border-bottom: 1px solid var(--border);
+        }
+
+        .mcp-list li:last-child {
+            border-bottom: none;
         }
 
         @media (max-width: 600px) {

--- a/src/pages/summaries/[...page].astro
+++ b/src/pages/summaries/[...page].astro
@@ -4,6 +4,7 @@ import SummaryNav from '../../components/SummaryNav.astro';
 import PostLink from '../../components/PostLink.astro';
 import Pagination from '../../components/Pagination.astro';
 import AnalyticsFooter from '../../components/AnalyticsFooter.astro';
+import '@fontsource/spectral/700.css';
 
 // Metadata
 let title = 'Overly Short Summaries';
@@ -32,7 +33,7 @@ const { page } = Astro.props;
             canonicalURL={canonicalURL}
             prev={page.url.prev}
             next={page.url.next}
-    >
+    />
 
     <style lang="scss">
       .title {
@@ -41,14 +42,21 @@ const { page } = Astro.props;
         margin-top: 2rem;
         margin-bottom: 0;
         text-align: center;
+        font-family: 'Spectral', serif;
+        font-weight: 700;
+        color: var(--accent);
       }
 
       .count {
         font-size: 1em;
         display: block;
         text-align: center;
+        color: var(--muted);
+        margin-top: 0.5rem;
+        margin-bottom: 0.5rem;
       }
     </style>
+    <link rel="stylesheet" href="/style/summaries.css">
 </head>
 
 <body>

--- a/src/pages/widgets.astro
+++ b/src/pages/widgets.astro
@@ -50,7 +50,7 @@ const embedOverrides = {
             background: var(--bg-panel);
             border: 1px solid var(--border);
             border-radius: 16px;
-            box-shadow: 0 6px 24px -12px rgba(40, 20, 10, 0.18);
+            box-shadow: var(--shadow-1);
             padding: 2rem 2.5rem;
         }
 


### PR DESCRIPTION
Implements the 5 **structural** proposals from the appearance review (`docs/appearance-review-2026-06-23/`), the follow-up to the quick-wins PR. Built through a demesne pipeline, re-scoped against the current (post-quick-wins) code, then visually validated by rendering the affected screens offline before this PR.

## What changed
- **SP1 — Summaries onto the design system.** Root cause of the section's divergence was that `summaries/[...page].astro` linked **no stylesheet**, so the shared `PostLink`/`TopicTags` pills rendered as plain links, the wrapper was full-bleed, and the heading was system-font. Extracted a shared `public/style/chips.css` (imported by `blog.css` + `summaries.css`), linked `summaries.css` on the index, gave it the Spectral+accent "All Summaries" heading, and re-cast the summary description as a sentence-case Spectral italic lede. Category tags now render as pills. *(Fixed an integration bug: `MainHead.astro` renders no `<slot>`, so the index's `<link>`/`<style>` only take effect as direct `<head>` siblings of a self-closed `<MainHead/>`.)*
- **SP2 — Reading measure.** Summary `.article` → 42rem, blog `.article` → 46rem (~65ch), centred; blog wrapper reconciled to 60rem (removed the 56rem override); doubled mobile padding halved.
- **SP3 — Real dark-mode elevation.** Raised dark `--bg-panel` (`#1b1f27` → `#252a35`) and introduced scheme-aware `--shadow-1`/`--shadow-2` tokens — light values identical to the old warm shadows (light mode unchanged), dark adds a black cast shadow + light inset edge so cards no longer sit flush. Consolidated the duplicated card shadows onto the tokens.
- **SP4 — Widget embed placeholder/fallback.** Each `<iframe>` now sits over a designed shell (bordered panel, centred glyph, widget name in Spectral accent, "View full page →" CTA), shown while loading and on load failure — no more blank voids. Pure-CSS layering, no remote assets.
- **SP5 — Composition density.** Home card widened 34rem → 40rem with a mobile cream frame restored; projects MCP-server list wrapped in a light list-card with subtle separators.

## Validation
- `astro build` clean (28 pages).
- Offline render of summaries index/post, blog post, home (desktop + mobile), projects (light + dark), widgets (light + dark), blog index (dark).
- Computed-style checks: summary `.topic-chip` `inline-flex`/999px pill, index title Spectral + accent, dark `--bg-panel` `#252a35`, shadow token = black drop + light inset edge.

## Note (pre-existing, out of scope)
Summary category pills link to `/blog/topics/<slug>/` via the shared `TopicTags` component (e.g. `rationality`), which has no matching blog-topic page — a pre-existing routing quirk now more visible as styled pills. Not changed here to avoid touching blog routing; can be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)