### PR TITLE
Render summary category tags as non-links

### DIFF
--- a/public/style/chips.css
+++ b/public/style/chips.css
@@ -14,8 +14,8 @@
     transition: color 0.15s, border-color 0.15s;
 }
 
-.topic-chip:hover,
-.topic-chip:focus {
+a.topic-chip:hover,
+a.topic-chip:focus {
     color: var(--accent);
     border-color: var(--accent);
 }
@@ -37,8 +37,8 @@
     transition: background 0.15s, border-color 0.15s;
 }
 
-.domain-badge:hover,
-.domain-badge:focus {
+a.domain-badge:hover,
+a.domain-badge:focus {
     background: color-mix(in srgb, var(--accent) 20%, transparent);
     border-color: var(--accent);
 }

--- a/src/components/PostLink.astro
+++ b/src/components/PostLink.astro
@@ -1,7 +1,7 @@
 ---
 import TopicTags from './TopicTags.astro';
 
-const { author, post } = Astro.props;
+const { author, post, linkTags = true } = Astro.props;
 
 function formatDate(date) {
 return new Date(date).toUTCString().replace(/(\d\d\d\d) .*/, '$1'); // remove everything after YYYY
@@ -79,5 +79,5 @@ return new Date(date).toUTCString().replace(/(\d\d\d\d) .*/, '$1'); // remove ev
         </p>
     </div>
 </a>
-<TopicTags categories={post.frontmatter.categories} domain={post.frontmatter.domain} />
+<TopicTags categories={post.frontmatter.categories} domain={post.frontmatter.domain} linkable={linkTags} />
 </div>

--- a/src/components/TopicTags.astro
+++ b/src/components/TopicTags.astro
@@ -1,5 +1,5 @@
 ---
-const { categories, domain } = Astro.props;
+const { categories, domain, linkable = true } = Astro.props;
 const cats = Array.isArray(categories) ? categories : [];
 const chips = cats.map((c) => ({
   slug: String(c).toLowerCase().replaceAll('_', '-'),
@@ -11,10 +11,12 @@ const domainLabel = domain ? String(domain).charAt(0).toUpperCase() + String(dom
 ---
 {(domain || chips.length > 0) && (
   <ul class="topics">
-    {domain && <li><a class="domain-badge" href={`/blog/${domainSlug}/`}>{domainLabel}</a></li>}
-    {chips.map((c) => (
-      <li><a class="topic-chip" href={`/blog/topics/${c.slug}/`}>{c.label}</a></li>
-    ))}
+    {domain && (linkable
+      ? <li><a class="domain-badge" href={`/blog/${domainSlug}/`}>{domainLabel}</a></li>
+      : <li><span class="domain-badge">{domainLabel}</span></li>)}
+    {chips.map((c) => (linkable
+      ? <li><a class="topic-chip" href={`/blog/topics/${c.slug}/`}>{c.label}</a></li>
+      : <li><span class="topic-chip">{c.label}</span></li>))}
   </ul>
 )}
 <style lang="scss">

--- a/src/pages/summaries/[...page].astro
+++ b/src/pages/summaries/[...page].astro
@@ -65,7 +65,7 @@ const { page } = Astro.props;
 <main class="wrapper">
     <h2 class="title">All Summaries</h2>
     <small class="count">{page.start + 1}–{page.end + 1} of {page.total}</small>
-    {page.data.map((post) => <PostLink post={post} />)}
+    {page.data.map((post) => <PostLink post={post} linkTags={false} />)}
 </main>
 
 <footer>


### PR DESCRIPTION
Follow-up to the structural appearance PR. Summary categories (e.g. `rationality`, `uncategorised`) were rendered as `TopicTags` pills linking to `/blog/topics/<slug>/`, but no such blog-topic pages exist — so those pills 404'd.

`TopicTags` gains a `linkable` prop (default `true`): blog tags keep linking to their real topic/domain pages, while the summaries index passes `linkable={false}` so categories render as plain `<span>` pills. Hover/focus styling is now anchor-only so the static pills don't imply interactivity.

## Validation
- `astro build` clean (28 pages).
- Built HTML confirmed: summaries index → `<span class="topic-chip">` (no href); blog index → `<a class="topic-chip" href="/blog/topics/…">` unchanged.
- Rendered summaries index — pills visually identical, no longer clickable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)