### PR TITLE
Trim glowficlog blurb on /projects

### DIFF
--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -238,7 +238,7 @@ for (const [slug, pair] of Object.entries(sources)) {
             imageAlt="The glowficlog reader showing a condensed glowfic thread"
         >
             <h3 class="card-title">glowficlog</h3>
-            <p>A browser extension that reformats glowfic.com thread pages into a compact, high-density reader, collapsing endless one-post-per-line forum formatting into a continuous, novel-like column with alternating gutter icons. I built it because long threads were a slog to read in their native layout.</p>
+            <p>A browser extension that reformats glowfic.com thread pages into a compact, high-density reader, collapsing endless one-post-per-line forum formatting into a continuous, novel-like column with alternating gutter icons.</p>
         </FeaturedMediaCard>
 
         <h2>Widgets</h2>


### PR DESCRIPTION
## Summary
- Drops the "long threads were a slog" justification from the glowficlog card blurb, leaving just what the extension does.

## Test plan
- [x] `npm run build` succeeds