### PR TITLE
Give large content panels their own darker background token

### DIFF
--- a/public/style/global.css
+++ b/public/style/global.css
@@ -16,6 +16,9 @@
   /* Theme tokens (light) */
   --bg: #faf6f0;
   --bg-panel: #fffdfa;
+  /* Large read-only content panels (article body, home bio) — a small step up
+     from --bg, distinct from --bg-panel's cards/nav which sit further forward. */
+  --bg-content: #fcf9f4;
   --fg: #20242b;
   --muted: #5f574c;
   --accent: #9d2235;
@@ -34,6 +37,7 @@
 
     --bg: #14171d;
     --bg-panel: #252a35;
+    --bg-content: #181c24;
     --fg: #e9e6e1;
     --muted: #d2d7df;
     --accent: #efa6b3;

--- a/src/layouts/blog.astro
+++ b/src/layouts/blog.astro
@@ -47,7 +47,7 @@ const { content } = Astro.props;
         margin-bottom: 6rem;
         max-width: 46rem;
         margin-inline: auto;
-        background: var(--bg-panel);
+        background: var(--bg-content);
         border: 1px solid var(--border);
         border-radius: 16px;
         box-shadow: var(--shadow-2);

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -27,7 +27,7 @@ import '@fontsource/spectral/700.css';
         main {
             max-width: 40rem;
             width: 100%;
-            background: var(--bg-panel);
+            background: var(--bg-content);
             border: 1px solid var(--border);
             border-radius: 16px;
             padding: 2rem 2.5rem 2.5rem;


### PR DESCRIPTION
## Summary
- Splits `--bg-panel` (cards, nav) from a new `--bg-content` token used by the blog `.article` body and the home page's bio panel — those are read-only prose content, not cards.
- `--bg-content` sits a small step above `--bg` (the true page background) in both themes, giving long-form reading noticeably more contrast against its panel without the large jump `--bg-panel` was making, and without darkening every card on the site.
- Nested "well" elements (`.row` links, inline `code`) are untouched — they already used `--bg` directly, which stays visibly darker than the new `--bg-content`, so the inset effect still reads correctly.

Follows up on a dark-mode readability review of the "Takes On Local AI Pipelines - Introducing Demesne" post.

## Test plan
- [x] `npm run build` succeeds
- [x] Rendered home and the demesne post in dark mode via a headless browser sandbox — panels read darker/higher-contrast, `.row` link boxes and inline code remain visually inset
- [ ] Spot-check light mode and a couple of other blog posts in a live browser before merging