### PR TITLE
Switch site identity typeface from Spectral to Schibsted Grotesk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@astrojs/mdx": "^6.0.3",
         "@astrojs/sitemap": "^3.7.3",
-        "@fontsource/spectral": "^5.2.8"
+        "@fontsource/ibm-plex-sans-jp": "^5.2.8",
+        "@fontsource/schibsted-grotesk": "^5.2.8"
       },
       "devDependencies": {
         "@astrojs/react": "^5.0.7",
@@ -1078,10 +1079,19 @@
         "node": ">=18"
       }
     },
-    "node_modules/@fontsource/spectral": {
+    "node_modules/@fontsource/ibm-plex-sans-jp": {
       "version": "5.2.8",
-      "resolved": "https://registry.npmjs.org/@fontsource/spectral/-/spectral-5.2.8.tgz",
-      "integrity": "sha512-0CqZ8/z8A38BdeSz5t2NSd5tCO1R9P1k7SF2VpRLMbZTMSSR6+2Dk0ZBMfEQK/IrBLQS1HgHLMqpdTwRpnKpGQ==",
+      "resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-sans-jp/-/ibm-plex-sans-jp-5.2.8.tgz",
+      "integrity": "sha512-ULgJLBVJEBIKBddVFla4PiOCHM4a7wjThS9FtMbmc9YehcYmnuMtF8/mi9ItZobHpQGwChzF/7ujoUTs+cYbZw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/schibsted-grotesk": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/schibsted-grotesk/-/schibsted-grotesk-5.2.8.tgz",
+      "integrity": "sha512-CyyDW5aS89oKGFAVndOsJTQ5pqzKuPnSKWjrdJdMT5TD/eA2JyWapUBhvy6X/lqqrB/GNk74PIff7coPifeVyg==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@astrojs/mdx": "^6.0.3",
     "@astrojs/sitemap": "^3.7.3",
-    "@fontsource/spectral": "^5.2.8"
+    "@fontsource/ibm-plex-sans-jp": "^5.2.8",
+    "@fontsource/schibsted-grotesk": "^5.2.8"
   }
 }

--- a/src/components/SiteHeader.astro
+++ b/src/components/SiteHeader.astro
@@ -29,7 +29,7 @@ import MainNav from './MainNav.astro';
   }
 
   .title {
-    font-family: 'Spectral', serif;
+    font-family: 'Schibsted Grotesk', 'IBM Plex Sans JP', sans-serif;
     font-size: 1.5em;
     letter-spacing: -0.02em;
     font-weight: 700;
@@ -38,7 +38,7 @@ import MainNav from './MainNav.astro';
   }
 
   .subtitle {
-    font-family: 'Spectral', serif;
+    font-family: 'Schibsted Grotesk', 'IBM Plex Sans JP', sans-serif;
     font-size: 1em;
     color: var(--muted);
     margin-top: 0.3em;

--- a/src/components/WidgetEmbed.astro
+++ b/src/components/WidgetEmbed.astro
@@ -50,7 +50,7 @@ const name = title ?? slug;
     line-height: 0;
   }
   .widget-name {
-    font-family: 'Spectral', serif;
+    font-family: 'Schibsted Grotesk', 'IBM Plex Sans JP', sans-serif;
     font-weight: 700;
     color: var(--accent);
     font-size: 1.1rem;

--- a/src/layouts/blog.astro
+++ b/src/layouts/blog.astro
@@ -3,10 +3,12 @@ import MainHead from '../components/MainHead.astro';
 import BlogNav from '../components/BlogNav.astro';
 import AnalyticsFooter from '../components/AnalyticsFooter.astro';
 import TopicTags from '../components/TopicTags.astro';
-import '@fontsource/spectral/400.css';
-import '@fontsource/spectral/400-italic.css';
-import '@fontsource/spectral/700.css';
-import '@fontsource/spectral/700-italic.css';
+import '@fontsource/schibsted-grotesk/400.css';
+import '@fontsource/schibsted-grotesk/400-italic.css';
+import '@fontsource/schibsted-grotesk/700.css';
+import '@fontsource/schibsted-grotesk/700-italic.css';
+import '@fontsource/ibm-plex-sans-jp/400.css';
+import '@fontsource/ibm-plex-sans-jp/700.css';
 
 const { content } = Astro.props;
 ---
@@ -17,7 +19,7 @@ const { content } = Astro.props;
     <link rel="stylesheet" href="/style/blog.css">
     <style lang="scss">
       body {
-        font-family: 'Spectral', serif;
+        font-family: 'Schibsted Grotesk', 'IBM Plex Sans JP', sans-serif;
       }
 
       .title {

--- a/src/layouts/summary.astro
+++ b/src/layouts/summary.astro
@@ -2,10 +2,12 @@
 import MainHead from '../components/MainHead.astro';
 import SummaryNav from '../components/SummaryNav.astro';
 import AnalyticsFooter from '../components/AnalyticsFooter.astro';
-import '@fontsource/spectral/400.css';
-import '@fontsource/spectral/400-italic.css';
-import '@fontsource/spectral/700.css';
-import '@fontsource/spectral/700-italic.css';
+import '@fontsource/schibsted-grotesk/400.css';
+import '@fontsource/schibsted-grotesk/400-italic.css';
+import '@fontsource/schibsted-grotesk/700.css';
+import '@fontsource/schibsted-grotesk/700-italic.css';
+import '@fontsource/ibm-plex-sans-jp/400.css';
+import '@fontsource/ibm-plex-sans-jp/700.css';
 
 const { content } = Astro.props;
 ---
@@ -16,7 +18,7 @@ const { content } = Astro.props;
     <link rel="stylesheet" href="/style/summaries.css">
     <style lang="scss">
       body {
-        font-family: 'Spectral', serif;
+        font-family: 'Schibsted Grotesk', 'IBM Plex Sans JP', sans-serif;
       }
 
       .title {

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -4,7 +4,8 @@ import BlogNav from '../../components/BlogNav.astro';
 import PostLink from '../../components/PostLink.astro';
 import Pagination from '../../components/Pagination.astro';
 import AnalyticsFooter from '../../components/AnalyticsFooter.astro';
-import '@fontsource/spectral/700.css';
+import '@fontsource/schibsted-grotesk/700.css';
+import '@fontsource/ibm-plex-sans-jp/700.css';
 
 // Metadata
 let title = 'Working Notes';
@@ -37,7 +38,7 @@ const { page } = Astro.props;
 
     <style lang="scss">
       .title {
-        font-family: 'Spectral', serif;
+        font-family: 'Schibsted Grotesk', 'IBM Plex Sans JP', sans-serif;
         font-weight: 700;
         font-size: 3em;
         letter-spacing: -0.04em;

--- a/src/pages/blog/[domain].astro
+++ b/src/pages/blog/[domain].astro
@@ -3,7 +3,8 @@ import MainHead from '../../components/MainHead.astro';
 import BlogNav from '../../components/BlogNav.astro';
 import PostLink from '../../components/PostLink.astro';
 import AnalyticsFooter from '../../components/AnalyticsFooter.astro';
-import '@fontsource/spectral/700.css';
+import '@fontsource/schibsted-grotesk/700.css';
+import '@fontsource/ibm-plex-sans-jp/700.css';
 
 export async function getStaticPaths() {
   let posts = Object.values(import.meta.glob('./*.md', { eager: true }));
@@ -36,7 +37,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
     <link rel="stylesheet" href="/style/blog.css">
     <style lang="scss">
       .title {
-        font-family: 'Spectral', serif;
+        font-family: 'Schibsted Grotesk', 'IBM Plex Sans JP', sans-serif;
         font-weight: 700;
         font-size: 3em;
         letter-spacing: -0.04em;

--- a/src/pages/blog/topics/[slug].astro
+++ b/src/pages/blog/topics/[slug].astro
@@ -3,7 +3,8 @@ import MainHead from '../../../components/MainHead.astro';
 import BlogNav from '../../../components/BlogNav.astro';
 import PostLink from '../../../components/PostLink.astro';
 import AnalyticsFooter from '../../../components/AnalyticsFooter.astro';
-import '@fontsource/spectral/700.css';
+import '@fontsource/schibsted-grotesk/700.css';
+import '@fontsource/ibm-plex-sans-jp/700.css';
 
 export async function getStaticPaths() {
   let posts = Object.values(import.meta.glob('../*.md', { eager: true }));
@@ -37,7 +38,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
     <link rel="stylesheet" href="/style/blog.css">
     <style lang="scss">
       .title {
-        font-family: 'Spectral', serif;
+        font-family: 'Schibsted Grotesk', 'IBM Plex Sans JP', sans-serif;
         font-weight: 700;
         font-size: 3em;
         letter-spacing: -0.04em;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,9 +4,11 @@ import AnalyticsBody from '../components/AnalyticsBody.astro';
 import AnalyticsFooter from '../components/AnalyticsFooter.astro';
 import {Image} from "astro:assets";
 import avatar from '../assets/avatar.png'
-import '@fontsource/spectral/400.css';
-import '@fontsource/spectral/400-italic.css';
-import '@fontsource/spectral/700.css';
+import '@fontsource/schibsted-grotesk/400.css';
+import '@fontsource/schibsted-grotesk/400-italic.css';
+import '@fontsource/schibsted-grotesk/700.css';
+import '@fontsource/ibm-plex-sans-jp/400.css';
+import '@fontsource/ibm-plex-sans-jp/700.css';
 ---
 <!doctype html>
 <html lang="en">
@@ -35,7 +37,7 @@ import '@fontsource/spectral/700.css';
         }
 
         .bio {
-            font-family: 'Spectral', serif;
+            font-family: 'Schibsted Grotesk', 'IBM Plex Sans JP', sans-serif;
             font-style: italic;
             font-size: 1.2rem;
             line-height: 1.5;
@@ -45,7 +47,7 @@ import '@fontsource/spectral/700.css';
         }
 
         h2 {
-            font-family: 'Spectral', serif;
+            font-family: 'Schibsted Grotesk', 'IBM Plex Sans JP', sans-serif;
             font-weight: 700;
             color: var(--accent);
             font-size: 1.4rem;

--- a/src/pages/privacy/glowficlog.astro
+++ b/src/pages/privacy/glowficlog.astro
@@ -2,9 +2,11 @@
 import MainHead from '../../components/MainHead.astro';
 import SiteHeader from '../../components/SiteHeader.astro';
 import AnalyticsFooter from '../../components/AnalyticsFooter.astro';
-import '@fontsource/spectral/400.css';
-import '@fontsource/spectral/400-italic.css';
-import '@fontsource/spectral/700.css';
+import '@fontsource/schibsted-grotesk/400.css';
+import '@fontsource/schibsted-grotesk/400-italic.css';
+import '@fontsource/schibsted-grotesk/700.css';
+import '@fontsource/ibm-plex-sans-jp/400.css';
+import '@fontsource/ibm-plex-sans-jp/700.css';
 ---
 <!doctype html>
 <html lang="en">
@@ -20,7 +22,7 @@ import '@fontsource/spectral/700.css';
         }
 
         h1 {
-            font-family: 'Spectral', serif;
+            font-family: 'Schibsted Grotesk', 'IBM Plex Sans JP', sans-serif;
             font-weight: 700;
             color: var(--accent);
             font-size: 2.2rem;
@@ -36,7 +38,7 @@ import '@fontsource/spectral/700.css';
         }
 
         h2 {
-            font-family: 'Spectral', serif;
+            font-family: 'Schibsted Grotesk', 'IBM Plex Sans JP', sans-serif;
             font-weight: 700;
             color: var(--accent);
             font-size: 1.4rem;

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -12,9 +12,11 @@ import pennsicDark from '../assets/projects/pennsic-planner-dark.jpg';
 import glowficlogLight from '../assets/projects/glowficlog-light.jpg';
 import glowficlogDark from '../assets/projects/glowficlog-dark.jpg';
 import { widgets, mcpServers } from '../data/projects.js';
-import '@fontsource/spectral/400.css';
-import '@fontsource/spectral/400-italic.css';
-import '@fontsource/spectral/700.css';
+import '@fontsource/schibsted-grotesk/400.css';
+import '@fontsource/schibsted-grotesk/400-italic.css';
+import '@fontsource/schibsted-grotesk/700.css';
+import '@fontsource/ibm-plex-sans-jp/400.css';
+import '@fontsource/ibm-plex-sans-jp/700.css';
 
 const sources = {
     'japanese-verb-tower': { light: jvtLight, dark: jvtDark },
@@ -46,7 +48,7 @@ for (const [slug, pair] of Object.entries(sources)) {
         }
 
         h1 {
-            font-family: 'Spectral', serif;
+            font-family: 'Schibsted Grotesk', 'IBM Plex Sans JP', sans-serif;
             font-weight: 700;
             color: var(--accent);
             font-size: 2.2rem;
@@ -61,7 +63,7 @@ for (const [slug, pair] of Object.entries(sources)) {
         }
 
         h2 {
-            font-family: 'Spectral', serif;
+            font-family: 'Schibsted Grotesk', 'IBM Plex Sans JP', sans-serif;
             font-weight: 700;
             color: var(--accent);
             font-size: 1.5rem;
@@ -79,7 +81,7 @@ for (const [slug, pair] of Object.entries(sources)) {
 
         /* Featured card */
         .card-title {
-            font-family: 'Spectral', serif;
+            font-family: 'Schibsted Grotesk', 'IBM Plex Sans JP', sans-serif;
             font-weight: 700;
             color: var(--accent);
             font-size: 1.6rem;
@@ -150,7 +152,7 @@ for (const [slug, pair] of Object.entries(sources)) {
         }
 
         .widget-title {
-            font-family: 'Spectral', serif;
+            font-family: 'Schibsted Grotesk', 'IBM Plex Sans JP', sans-serif;
             font-weight: 700;
             color: var(--accent);
             font-size: 1.15rem;

--- a/src/pages/summaries/[...page].astro
+++ b/src/pages/summaries/[...page].astro
@@ -4,7 +4,8 @@ import SummaryNav from '../../components/SummaryNav.astro';
 import PostLink from '../../components/PostLink.astro';
 import Pagination from '../../components/Pagination.astro';
 import AnalyticsFooter from '../../components/AnalyticsFooter.astro';
-import '@fontsource/spectral/700.css';
+import '@fontsource/schibsted-grotesk/700.css';
+import '@fontsource/ibm-plex-sans-jp/700.css';
 
 // Metadata
 let title = 'Overly Short Summaries';
@@ -42,7 +43,7 @@ const { page } = Astro.props;
         margin-top: 2rem;
         margin-bottom: 0;
         text-align: center;
-        font-family: 'Spectral', serif;
+        font-family: 'Schibsted Grotesk', 'IBM Plex Sans JP', sans-serif;
         font-weight: 700;
         color: var(--accent);
       }

--- a/src/pages/widgets.astro
+++ b/src/pages/widgets.astro
@@ -4,9 +4,11 @@ import SiteHeader from '../components/SiteHeader.astro';
 import AnalyticsFooter from '../components/AnalyticsFooter.astro';
 import WidgetEmbed from '../components/WidgetEmbed.astro';
 import widgets from '../data/widgets.json';
-import '@fontsource/spectral/400.css';
-import '@fontsource/spectral/400-italic.css';
-import '@fontsource/spectral/700.css';
+import '@fontsource/schibsted-grotesk/400.css';
+import '@fontsource/schibsted-grotesk/400-italic.css';
+import '@fontsource/schibsted-grotesk/700.css';
+import '@fontsource/ibm-plex-sans-jp/400.css';
+import '@fontsource/ibm-plex-sans-jp/700.css';
 
 const embedOverrides = {
     'pennsic-planner': 'https://pennsic-planner.widgets.beshir.org/#/c/o7lUWqX3FUlMA5wEyf7B_w',
@@ -26,7 +28,7 @@ const embedOverrides = {
         }
 
         h1 {
-            font-family: 'Spectral', serif;
+            font-family: 'Schibsted Grotesk', 'IBM Plex Sans JP', sans-serif;
             font-weight: 700;
             color: var(--accent);
             font-size: 2.2rem;
@@ -55,7 +57,7 @@ const embedOverrides = {
         }
 
         .card-title {
-            font-family: 'Spectral', serif;
+            font-family: 'Schibsted Grotesk', 'IBM Plex Sans JP', sans-serif;
             font-weight: 700;
             color: var(--accent);
             font-size: 1.5rem;


### PR DESCRIPTION
## Summary
- Replaces the serif Spectral with **Schibsted Grotesk** (a humanist grotesque originally commissioned by Bakken & Bæck for the Norwegian newspaper group Schibsted, open-sourced 2023) as the site's identity typeface, across every layout/page that referenced Spectral — headings, article body, home bio, blog index/topic/domain pages, summaries, projects, widgets, and the privacy policy.
- Adds **IBM Plex Sans JP** as an explicit fallback for CJK text (`font-family: 'Schibsted Grotesk', 'IBM Plex Sans JP', sans-serif`). This matters because neither Schibsted Grotesk nor the base `@fontsource/ibm-plex-sans` package include any Japanese glyphs — the JP coverage only exists in the separate `ibm-plex-sans-jp` package under its own distinct font-family name, so a plain repeat of "IBM Plex Sans" in the stack would not have worked.
- Follows a two-round side-by-side visual comparison (screenshots of the demesne post rendered in each candidate, dark mode) — see conversation for the full candidate set and rationale.

## Test plan
- [x] `npm run build` succeeds
- [x] Rendered the demesne post (dark) and home page (light) via a headless browser sandbox — Schibsted Grotesk applies correctly in both themes
- [x] Rendered a Latin+Japanese test string — confirmed the IBM Plex Sans JP fallback renders kanji/hiragana/katakana correctly where Schibsted Grotesk has no coverage
- [x] Grepped the repo for stray "Spectral" references — none remain
- [ ] Spot-check a couple more pages (projects, widgets, summaries) live before merging