### PR TITLE
Widen article measure and unify list/paragraph text size

### DIFF
--- a/src/layouts/blog.astro
+++ b/src/layouts/blog.astro
@@ -47,7 +47,7 @@ const { content } = Astro.props;
       .article {
         margin-top: 2rem;
         margin-bottom: 6rem;
-        max-width: 46rem;
+        max-width: 50rem;
         margin-inline: auto;
         background: var(--bg-panel);
         border: 1px solid var(--border);
@@ -55,7 +55,7 @@ const { content } = Astro.props;
         box-shadow: var(--shadow-2);
         padding: 2rem 2.5rem;
 
-        :global(p), :global(> ul) {
+        :global(p), :global(> ul), :global(> ol) {
           line-height: 1.6;
           margin-top: 2em;
           margin-bottom: 2em;
@@ -69,8 +69,8 @@ const { content } = Astro.props;
         :global(li) {
           margin-bottom: 0.6em;
         }
-        :global(p), :global(> ul) {
-          font-size: 1.3rem;
+        :global(p), :global(> ul), :global(> ol) {
+          font-size: 1.1rem;
         }
         :global(li > ul) {
           margin-top: 0.8em;


### PR DESCRIPTION
## Summary
- Widens `.article` from 46rem to 50rem and dials body text down from 1.3rem to 1.1rem, taking the measure from ~10-11 words/line to ~13-14 words/line (previously computed at ~808px content width / 19.8px font, vs. ~738px / 23.4px before).
- Gives top-level numbered lists (`> ol`) the same font-size and spacing rules as paragraphs and bullet lists. They previously had no font-size rule at all, so they fell back to the bare root size (~1rem) — a noticeably jarring step down from 1.3rem body text. Now both render at 1.1rem, matching exactly.

## Test plan
- [x] `npm run build` succeeds
- [x] Rendered the demesne post (which has a top-level numbered list) — confirmed via computed styles that `p`, `ol`, and `li` font-size all match at 19.8px
- [x] Checked mobile (380px) — no horizontal overflow
- [ ] Spot-check a couple more posts with lists live before merging