### PR TITLE
Blog index: remove title underline, shrink description text

### DIFF
--- a/src/components/PostLink.astro
+++ b/src/components/PostLink.astro
@@ -44,7 +44,7 @@ return new Date(date).toUTCString().replace(/(\d\d\d\d) .*/, '$1'); // remove ev
   }
 
   .description {
-    font-size: 1.25em;
+    font-size: 1em;
     color: var(--fg);
     margin-top: 0.5em;
   }
@@ -58,8 +58,6 @@ return new Date(date).toUTCString().replace(/(\d\d\d\d) .*/, '$1'); // remove ev
     margin-top: 0;
     margin-bottom: 0;
     color: var(--accent);
-    text-decoration: underline;
-    text-decoration-color: var(--accent);
   }
 
   time {


### PR DESCRIPTION
## Summary
- Removes the underline on post titles in the blog listing — the accent color already signals it's a link, and the underline was redundant decoration.
- Shrinks the post description from `1.25em` to `1em`. It had no explicit parent font-size context, so it was rendering larger than the article body text itself despite being secondary/supporting text — dialed back so it reads as a caption rather than a second headline.

## Test plan
- [x] `npm run build` succeeds
- [x] Rendered `/blog/` in both light and dark mode via a headless browser sandbox — confirmed no underline, description now visually subordinate to the title